### PR TITLE
Apply sync waves to subscriptions

### DIFF
--- a/values-hub.yaml
+++ b/values-hub.yaml
@@ -13,6 +13,8 @@ clusterGroup:
   subscriptions:
     serverless:
       name: serverless-operator
+      annotations:
+        argocd.argoproj.io/sync-wave: "-50"
       #namespace: openshift-serverless
       #channel: stable
       #source: redhat-operators
@@ -23,6 +25,8 @@ clusterGroup:
       channel: stable
       source: redhat-operators
       sourceNamespace: openshift-marketplace
+      annotations:
+        argocd.argoproj.io/sync-wave: "-50"
     nfd:
       name: nfd
       namespace: openshift-nfd
@@ -38,6 +42,8 @@ clusterGroup:
       channel: tech-preview-v1
       source: redhat-operators
       sourceNamespace: openshift-marketplace
+      annotations:
+        argocd.argoproj.io/sync-wave: "-50"
     rhoai:
       name: rhods-operator
       namespace: redhat-ods-operator


### PR DESCRIPTION
We make sure that these subscriptions are installed earlier.
While this does not yet give us a 100% guarantee that the DSCI + DSC
object created by the RHOAI operator gets stuck due to a race condition,
with this change I was never able to reproduce the install issue where
the three subscriptions (serverless, istio, authorino) got stuck.

Note: The subscription annotation has been added to the clustergroup chart
v0.9.7
